### PR TITLE
[feat + update] Áp dụng reCAPTCHA, rate-limiting cho các trang Auth

### DIFF
--- a/src/main/java/controller/AuthenticationController.java
+++ b/src/main/java/controller/AuthenticationController.java
@@ -1,8 +1,10 @@
 package controller;
 
+import dao.SecurityAttemptDAO;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import jakarta.servlet.annotation.*;
+import model.AuthTypes;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +20,10 @@ public class AuthenticationController extends HttpServlet {
     AuthServices authService = new AuthServices();
     EmailServices emailServices = new EmailServices();
     UserService userService = new UserService();
+    SecurityAttemptDAO securityAttemptDAO = new SecurityAttemptDAO();
+    private final AuthTypes actionTypeAuthentication = AuthTypes.AUTHENTICATION;
     private static final Logger log = LoggerFactory.getLogger(AuthenticationController.class);
+    private static final long OTP_COOLDOWN_TIME = 60000;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -52,8 +57,8 @@ public class AuthenticationController extends HttpServlet {
                 }
                 else {
                     Long lastOtpTime = (Long) session.getAttribute("otpTime");
-                    if (lastOtpTime != null && (System.currentTimeMillis() - lastOtpTime < 60000)) {
-                        long secondsLeft = (60000 - (System.currentTimeMillis() - lastOtpTime)) / 1000;
+                    if (lastOtpTime != null && (System.currentTimeMillis() - lastOtpTime < OTP_COOLDOWN_TIME)) {
+                        long secondsLeft = (OTP_COOLDOWN_TIME - (System.currentTimeMillis() - lastOtpTime)) / 1000;
                         request.setAttribute("emailError", "Vui lòng đợi " + secondsLeft + " giây nữa để gửi lại mã");
                     }
                     else {
@@ -81,8 +86,17 @@ public class AuthenticationController extends HttpServlet {
 
                 // ------------------------ Button cho xác nhận ---------------------------------
             } else if ("finish-otp".equals(action)) {
+                String clientIp = userService.getClientIp(request);
+                // Check ngay đầu
+                if (authService.isBlocked(finalEmail, clientIp, actionTypeAuthentication, 3, 60)) {
+                    session.removeAttribute("otpCode");
+                    request.setAttribute("otpError", "Bạn đã nhập sai mã OTP quá nhiều lần. Vui lòng thử lại sau 15 phút.");
+                    request.getRequestDispatcher("/auth/Authentication.jsp").forward(request, response);
+                    return;
+                }
                 String storedOtp = (String) session.getAttribute("otpCode");
                 if (otpInput != null && otpInput.equals(storedOtp)) {
+                    securityAttemptDAO.resetAttempts(finalEmail, clientIp, actionTypeAuthentication);
                     if (account != null) {
                         // luồng từ register
                         User realAccount = authService.register(
@@ -106,8 +120,14 @@ public class AuthenticationController extends HttpServlet {
                         response.sendRedirect(request.getContextPath() + "/forgotpassword");
                     }
                 } else {
-                    log.info("Xác thực OTP thành công cho luồng Quên mật khẩu");
-                    request.setAttribute("otpError", "Mã OTP không chính xác!");
+                    securityAttemptDAO.increaseAttempt(finalEmail, clientIp, actionTypeAuthentication);
+                    log.warn("Xác thực OTP thất bại cho email: {} từ IP: {}", finalEmail, clientIp);
+                    if (authService.isBlocked(finalEmail, clientIp, actionTypeAuthentication, 3, 60)) {
+                        session.removeAttribute("otpCode");
+                        request.setAttribute("otpError", "Bạn đã nhập sai quá nhiều lần. Mã OTP đã bị hủy, vui lòng thử lại sau 15 phút.");
+                    } else {
+                        request.setAttribute("otpError", "Mã OTP không chính xác!");
+                    }
                     request.getRequestDispatcher("/auth/Authentication.jsp").forward(request, response);
                 }
             }

--- a/src/main/java/controller/NormalLogin.java
+++ b/src/main/java/controller/NormalLogin.java
@@ -1,17 +1,16 @@
 package controller;
 
+import dao.SecurityAttemptDAO;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import jakarta.servlet.annotation.*;
+import model.AuthTypes;
 import model.Cart;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
-import services.AuthServices;
-import services.EmailServices;
-import services.UserService;
-import services.UserValidationServices;
+import services.*;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -22,6 +21,8 @@ public class NormalLogin extends HttpServlet {
     UserValidationServices userValidationServices = new UserValidationServices();
     AuthServices authServices = new AuthServices();
     UserService userService = new UserService();
+    SecurityAttemptDAO securityAttemptDAO = new SecurityAttemptDAO();
+    private final AuthTypes actionTypeLogin = AuthTypes.LOGIN;
     private static final Logger log = LoggerFactory.getLogger(NormalLogin.class);
 
     @Override
@@ -33,12 +34,11 @@ public class NormalLogin extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-
         authServices.baseSetupMdc(request, "searching for email that doesn't exist");
         try {
             String username = request.getParameter("username");
             String pass = request.getParameter("password");
-
+            String recaptchaResponse = request.getParameter("g-recaptcha-response");
             Map<String, String> allErrors = new HashMap<>(
                     userValidationServices.validateBothUsernameAndEmail(username, pass));
 
@@ -48,11 +48,22 @@ public class NormalLogin extends HttpServlet {
                 String loginKey = username.trim();
                 String clientIp = userService.getClientIp(request);
                 String targetEmail = authService.resolveEmail(loginKey);
-                if (authService.isLoginBlocked(targetEmail, clientIp)) {
+
+                int failedAttempts = securityAttemptDAO.getFailedAttempts(targetEmail, clientIp, actionTypeLogin, 15);
+                request.setAttribute("failedAttempts", failedAttempts);
+
+                if (authService.isBlocked(targetEmail, clientIp, actionTypeLogin, 5, 15)) {
                     log.warn("IP {} cố gắng đăng nhập vào {} nhưng đã bị khóa tạm thời.", clientIp, username);
                     request.setAttribute("loginError", "Bạn đã nhập sai quá nhiều. Vui lòng thử lại sau 15 phút.");
                     request.getRequestDispatcher("/auth/Login.jsp").forward(request, response);
                     return;
+                }
+                if (failedAttempts >= 3 && failedAttempts < 5) {
+                    if (!CaptchaVerifier.verify(recaptchaResponse)) {
+                        request.setAttribute("loginError", "Vui lòng xác minh bạn không phải là người máy!");
+                        request.getRequestDispatcher("/auth/Login.jsp").forward(request, response);
+                        return;
+                    }
                 }
                 account = authService.login(username, pass);
                 String emailOrUsername;
@@ -65,7 +76,7 @@ public class NormalLogin extends HttpServlet {
                 if (account != null) {
                     if (account.getActive() == 1) {
                         log.info("Đăng nhập thành công");
-                        authService.resetFailedLogin(targetEmail, clientIp);
+                        securityAttemptDAO.resetAttempts(targetEmail, clientIp, actionTypeLogin);
                         // ================
                         HttpSession oldSession = request.getSession(false);
                         Cart cart = null;
@@ -117,15 +128,19 @@ public class NormalLogin extends HttpServlet {
                     }
                 } else {
                     log.warn("Đăng nhập thất bại: Sai thông tin đăng nhập");
-                    authService.recordFailedLogin(targetEmail, clientIp);
-                    if (authService.isLoginBlocked(targetEmail, clientIp)) {
+                    securityAttemptDAO.increaseAttempt(targetEmail, clientIp, actionTypeLogin);
+                    int newAttempts = securityAttemptDAO.getFailedAttempts(targetEmail, clientIp, actionTypeLogin, 15);
+                    request.setAttribute("failedAttempts", newAttempts);
+
+                    if (newAttempts >= 5) {
                         EmailServices emailServices = new EmailServices();
                         new Thread(() -> {
                             emailServices.sendWarningBruteForcingMail(targetEmail, clientIp);
                         }).start();
-                        System.out.println("Đã gửi cảnh báo đến: " + targetEmail);
+                        request.setAttribute("loginError", "Bạn đã nhập sai quá nhiều. Vui lòng thử lại sau 15 phút.");
+                    } else {
+                        request.setAttribute("loginError", "Bạn đã nhập sai tên tài khoản hoặc mật khẩu");
                     }
-                    request.setAttribute("loginError", "Bạn đã nhập sai tên tài khoản hoặc mật khẩu");
                     request.getRequestDispatcher("/auth/Login.jsp").forward(request, response);
                 }
             } else {

--- a/src/main/java/controller/NormalLogin.java
+++ b/src/main/java/controller/NormalLogin.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import services.AuthServices;
+import services.EmailServices;
 import services.UserService;
 import services.UserValidationServices;
 
@@ -117,6 +118,13 @@ public class NormalLogin extends HttpServlet {
                 } else {
                     log.warn("Đăng nhập thất bại: Sai thông tin đăng nhập");
                     authService.recordFailedLogin(targetEmail, clientIp);
+                    if (authService.isLoginBlocked(targetEmail, clientIp)) {
+                        EmailServices emailServices = new EmailServices();
+                        new Thread(() -> {
+                            emailServices.sendWarningBruteForcingMail(targetEmail, clientIp);
+                        }).start();
+                        System.out.println("Đã gửi cảnh báo đến: " + targetEmail);
+                    }
                     request.setAttribute("loginError", "Bạn đã nhập sai tên tài khoản hoặc mật khẩu");
                     request.getRequestDispatcher("/auth/Login.jsp").forward(request, response);
                 }

--- a/src/main/java/controller/NormalLogin.java
+++ b/src/main/java/controller/NormalLogin.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import services.AuthServices;
+import services.UserService;
 import services.UserValidationServices;
 
 import java.io.IOException;
@@ -19,6 +20,7 @@ import java.util.Map;
 public class NormalLogin extends HttpServlet {
     UserValidationServices userValidationServices = new UserValidationServices();
     AuthServices authServices = new AuthServices();
+    UserService userService = new UserService();
     private static final Logger log = LoggerFactory.getLogger(NormalLogin.class);
 
     @Override
@@ -42,6 +44,15 @@ public class NormalLogin extends HttpServlet {
             User account;
             AuthServices authService = new AuthServices();
             if (allErrors.isEmpty()) {
+                String loginKey = username.trim();
+                String clientIp = userService.getClientIp(request);
+                String targetEmail = authService.resolveEmail(loginKey);
+                if (authService.isLoginBlocked(targetEmail, clientIp)) {
+                    log.warn("IP {} cố gắng đăng nhập vào {} nhưng đã bị khóa tạm thời.", clientIp, username);
+                    request.setAttribute("loginError", "Bạn đã nhập sai quá nhiều. Vui lòng thử lại sau 15 phút.");
+                    request.getRequestDispatcher("/auth/Login.jsp").forward(request, response);
+                    return;
+                }
                 account = authService.login(username, pass);
                 String emailOrUsername;
                 if (username.contains("@")) {
@@ -53,6 +64,8 @@ public class NormalLogin extends HttpServlet {
                 if (account != null) {
                     if (account.getActive() == 1) {
                         log.info("Đăng nhập thành công");
+                        authService.resetFailedLogin(targetEmail, clientIp);
+                        // ================
                         HttpSession oldSession = request.getSession(false);
                         Cart cart = null;
                         Cart buyNowCart = null;
@@ -103,6 +116,7 @@ public class NormalLogin extends HttpServlet {
                     }
                 } else {
                     log.warn("Đăng nhập thất bại: Sai thông tin đăng nhập");
+                    authService.recordFailedLogin(targetEmail, clientIp);
                     request.setAttribute("loginError", "Bạn đã nhập sai tên tài khoản hoặc mật khẩu");
                     request.getRequestDispatcher("/auth/Login.jsp").forward(request, response);
                 }

--- a/src/main/java/controller/RegisterController.java
+++ b/src/main/java/controller/RegisterController.java
@@ -1,14 +1,18 @@
 package controller;
 
+import dao.SecurityAttemptDAO;
 import dao.UserDAO;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import jakarta.servlet.annotation.*;
+import model.AuthTypes;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import services.AuthServices;
+import services.CaptchaVerifier;
+import services.UserService;
 import services.UserValidationServices;
 
 import java.io.IOException;
@@ -16,11 +20,13 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 @WebServlet(name = "RegisterController", value = "/register")
 public class RegisterController extends HttpServlet {
     UserDAO userDAO = new UserDAO();
+    SecurityAttemptDAO securityAttemptDAO = new SecurityAttemptDAO();
+    private final AuthTypes actionTypeRegister = AuthTypes.REGISTER;
+    UserService userService = new UserService();
     AuthServices authServices = new AuthServices();
     private static final Logger log = LoggerFactory.getLogger(RegisterController.class);
     @Override
@@ -40,10 +46,24 @@ public class RegisterController extends HttpServlet {
         String phoneNumber = request.getParameter("phone-number");
         String birth = request.getParameter("birth");
         String confirmPassword = request.getParameter("confirm-password");
+        String clientIp = userService.getClientIp(request);
 
         authServices.baseSetupMdc(request, email);
-
+        String recaptchaResponse = request.getParameter("g-recaptcha-response");
+        if (!CaptchaVerifier.verify(recaptchaResponse)) {
+            request.setAttribute("registerError", "Vui lòng xác minh bạn không phải là người máy!");
+            request.getRequestDispatcher("/auth/Register.jsp").forward(request, response);
+            return;
+        }
         try {
+            int registerCount = securityAttemptDAO.countRegisterAttemptsByIp(clientIp, 24);
+            if (registerCount >= 3) {
+                log.warn("IP {} đã vượt quá hạn mức tạo tài khoản cho phép trong 1 nga.", clientIp);
+                request.setAttribute("registerError", "Địa chỉ mạng của bạn đã gửi quá nhiều yêu cầu đăng ký. Vui lòng thử lại sau 1 ngày.");
+                request.getRequestDispatcher("/auth/Register.jsp").forward(request, response);
+                return;
+            }
+
             Map<String, String> allErrors = new HashMap<>();
             UserValidationServices userValidationServices = new UserValidationServices();
             allErrors.putAll(userValidationServices.validateEmail(email));
@@ -66,6 +86,7 @@ public class RegisterController extends HttpServlet {
             String registerUrl = "/auth/Register.jsp";
             // Nếu là false thì pass
             if (allErrors.isEmpty()) {
+                securityAttemptDAO.increaseAttempt(email, clientIp, actionTypeRegister);
                 log.info("Chờ xác thực tài khoản mới");
                 String fullName = lastname + " " + firstname;
                 LocalDate birthDay = LocalDate.parse(birth);

--- a/src/main/java/dao/SecurityAttemptDAO.java
+++ b/src/main/java/dao/SecurityAttemptDAO.java
@@ -16,19 +16,20 @@ public class SecurityAttemptDAO extends ADAO {
                 .execute() > 0);
     }
 
-    public int getFailedAttempts(String email, String ipAddress, AuthTypes actionType) {
+    public int getFailedAttempts(String email, String ipAddress, AuthTypes actionType, int minute) {
         String sql = """
             SELECT attempts 
             FROM security_attempts 
             WHERE target_email = :email 
               AND ip_address = :ip 
               AND action_type = :action
-              AND last_attempt > NOW() - INTERVAL 15 MINUTE
+              AND last_attempt > NOW() - INTERVAL :minute MINUTE
             """;
         return jdbi.withHandle(handle -> handle.createQuery(sql)
                 .bind("email", email)
                 .bind("ip", ipAddress)
                 .bind("action", actionType.name())
+                .bind("minute", minute)
                 .mapTo(Integer.class)
                 .findFirst()
                 .orElse(0));
@@ -46,5 +47,23 @@ public class SecurityAttemptDAO extends ADAO {
                 .bind("ip", ipAddress)
                 .bind("action", actionType.name())
                 .execute());
+    }
+
+    public int countRegisterAttemptsByIp(String ipAddress, int hour) {
+        String sql = """
+        SELECT SUM(attempts) 
+        FROM security_attempts 
+        WHERE ip_address = :ip 
+          AND action_type = :action
+          AND last_attempt > NOW() - INTERVAL :hour HOUR
+        """;
+
+        return jdbi.withHandle(handle -> handle.createQuery(sql)
+                .bind("ip", ipAddress)
+                .bind("action", AuthTypes.REGISTER.name())
+                .bind("hour", hour)
+                .mapTo(Integer.class)
+                .findFirst()
+                .orElse(0));
     }
 }

--- a/src/main/java/dao/SecurityAttemptDAO.java
+++ b/src/main/java/dao/SecurityAttemptDAO.java
@@ -1,0 +1,50 @@
+package dao;
+
+import model.AuthTypes;
+
+public class SecurityAttemptDAO extends ADAO {
+    public boolean increaseAttempt(String email, String ipAddress, AuthTypes actionType) {
+        String sql = """
+            INSERT INTO security_attempts (target_email, ip_address, action_type, attempts) 
+            VALUES (:email, :ip, :action, 1)
+            ON DUPLICATE KEY UPDATE attempts = attempts + 1
+            """;
+        return jdbi.withHandle(handle -> handle.createUpdate(sql)
+                .bind("email", email)
+                .bind("ip", ipAddress)
+                .bind("action", actionType.name())
+                .execute() > 0);
+    }
+
+    public int getFailedAttempts(String email, String ipAddress, AuthTypes actionType) {
+        String sql = """
+            SELECT attempts 
+            FROM security_attempts 
+            WHERE target_email = :email 
+              AND ip_address = :ip 
+              AND action_type = :action
+              AND last_attempt > NOW() - INTERVAL 15 MINUTE
+            """;
+        return jdbi.withHandle(handle -> handle.createQuery(sql)
+                .bind("email", email)
+                .bind("ip", ipAddress)
+                .bind("action", actionType.name())
+                .mapTo(Integer.class)
+                .findFirst()
+                .orElse(0));
+    }
+
+    public void resetAttempts(String email, String ipAddress, AuthTypes actionType) {
+        String sql = """
+            DELETE FROM security_attempts 
+            WHERE target_email = :email 
+              AND ip_address = :ip 
+              AND action_type = :action
+            """;
+        jdbi.withHandle(handle -> handle.createUpdate(sql)
+                .bind("email", email)
+                .bind("ip", ipAddress)
+                .bind("action", actionType.name())
+                .execute());
+    }
+}

--- a/src/main/java/model/AuthTypes.java
+++ b/src/main/java/model/AuthTypes.java
@@ -3,5 +3,5 @@ package model;
 public enum AuthTypes {
     LOGIN,
     REGISTER,
-    FORGOT_PASSWORD
+    AUTHENTICATION
 }

--- a/src/main/java/model/AuthTypes.java
+++ b/src/main/java/model/AuthTypes.java
@@ -1,0 +1,7 @@
+package model;
+
+public enum AuthTypes {
+    LOGIN,
+    REGISTER,
+    FORGOT_PASSWORD
+}

--- a/src/main/java/model/SecurityAttempt.java
+++ b/src/main/java/model/SecurityAttempt.java
@@ -1,0 +1,73 @@
+package model;
+
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+
+import java.sql.Timestamp;
+
+public class SecurityAttempt {
+    @ColumnName("id")
+    private Integer id;
+
+    @ColumnName("ip_address")
+    private String ipAddress;
+
+    @ColumnName("target_email")
+    private String targetEmail;
+
+    @ColumnName("action_type")
+    private AuthTypes actionType;
+
+    @ColumnName("attempts")
+    private int attempts;
+
+    @ColumnName("last_attempt")
+    private Timestamp lastAttempt;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public int getAttempts() {
+        return attempts;
+    }
+
+    public void setAttempts(int attempts) {
+        this.attempts = attempts;
+    }
+
+    public Timestamp getLastAttempt() {
+        return lastAttempt;
+    }
+
+    public void setLastAttempt(Timestamp lastAttempt) {
+        this.lastAttempt = lastAttempt;
+    }
+
+    public String getTargetEmail() {
+        return targetEmail;
+    }
+
+    public void setTargetEmail(String targetEmail) {
+        this.targetEmail = targetEmail;
+    }
+
+    public AuthTypes getActionType() {
+        return actionType;
+    }
+
+    public void setActionType(AuthTypes actionType) {
+        this.actionType = actionType;
+    }
+}

--- a/src/main/java/services/AuthServices.java
+++ b/src/main/java/services/AuthServices.java
@@ -9,7 +9,6 @@ import dao.UserDAO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import model.AuthTypes;
-import model.SecurityAttempt;
 import model.User;
 import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.MDC;
@@ -23,10 +22,6 @@ import java.util.UUID;
 public class AuthServices {
     private final UserDAO userDAO = new UserDAO();
     private final UserService userService = new UserService();
-
-    private final AuthTypes actionTypeLogin = AuthTypes.LOGIN;
-    private final AuthTypes actionTypeRegister = AuthTypes.REGISTER;
-    private final AuthTypes actionTypeFp = AuthTypes.FORGOT_PASSWORD;
 
     private final SecurityAttemptDAO securityAttemptDAO = new SecurityAttemptDAO();
     private static final String CLIENT_ID = "561993862196-rspl5j67m79f0857je2sdrv8f75m2ijs.apps.googleusercontent.com";
@@ -100,19 +95,9 @@ public class AuthServices {
     }
 
     // kiểm tra xem cặp IP/Email này có đang bị khóa không
-    public boolean isLoginBlocked(String email, String ipAddress) {
-        int failedAttempts = securityAttemptDAO.getFailedAttempts(email, ipAddress, actionTypeLogin);
-        return failedAttempts >= 5;
-    }
-
-    // hàm check khi điền sai mật khẩu/tài khoản để tăng số lần đếm
-    public void recordFailedLogin(String email, String ipAddress) {
-        securityAttemptDAO.increaseAttempt(email, ipAddress, actionTypeLogin);
-    }
-
-    // hàm check khi đăng nhập thành công để reset bộ đếm về 0
-    public void resetFailedLogin(String email, String ipAddress) {
-        securityAttemptDAO.resetAttempts(email, ipAddress, actionTypeLogin);
+    public boolean isBlocked(String email, String ipAddress, AuthTypes actionType, int attempts, int minuteForFailed) {
+        int failedAttempts = securityAttemptDAO.getFailedAttempts(email, ipAddress, actionType, minuteForFailed);
+        return failedAttempts >= attempts;
     }
 
     public User register(String fullName, String email, String username, String plainPassword, String phoneNumber, Timestamp birthday) {

--- a/src/main/java/services/AuthServices.java
+++ b/src/main/java/services/AuthServices.java
@@ -4,9 +4,12 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
+import dao.SecurityAttemptDAO;
 import dao.UserDAO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import model.AuthTypes;
+import model.SecurityAttempt;
 import model.User;
 import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.MDC;
@@ -20,6 +23,12 @@ import java.util.UUID;
 public class AuthServices {
     private final UserDAO userDAO = new UserDAO();
     private final UserService userService = new UserService();
+
+    private final AuthTypes actionTypeLogin = AuthTypes.LOGIN;
+    private final AuthTypes actionTypeRegister = AuthTypes.REGISTER;
+    private final AuthTypes actionTypeFp = AuthTypes.FORGOT_PASSWORD;
+
+    private final SecurityAttemptDAO securityAttemptDAO = new SecurityAttemptDAO();
     private static final String CLIENT_ID = "561993862196-rspl5j67m79f0857je2sdrv8f75m2ijs.apps.googleusercontent.com";
 
     public String getEmailFromGoogleToken(String idTokenString){
@@ -74,6 +83,36 @@ public class AuthServices {
         } else {
             return null;
         }
+    }
+
+    // Dù user có login bằng username cũng lấy được email
+    public String resolveEmail(String loginKey) {
+        // loginKey ở đây có thể là username hoặc là email
+        // nếu loginKey chứa @ thì là email (vì đặt tên username đã validation chuyện này)
+        if (loginKey.contains("@")) {
+            return loginKey.toLowerCase();
+        }
+        User user = userDAO.findByUsername(loginKey);
+        if (user != null && user.getEmail() != null) {
+            return user.getEmail().toLowerCase();
+        }
+        return loginKey.toLowerCase();
+    }
+
+    // kiểm tra xem cặp IP/Email này có đang bị khóa không
+    public boolean isLoginBlocked(String email, String ipAddress) {
+        int failedAttempts = securityAttemptDAO.getFailedAttempts(email, ipAddress, actionTypeLogin);
+        return failedAttempts >= 5;
+    }
+
+    // hàm check khi điền sai mật khẩu/tài khoản để tăng số lần đếm
+    public void recordFailedLogin(String email, String ipAddress) {
+        securityAttemptDAO.increaseAttempt(email, ipAddress, actionTypeLogin);
+    }
+
+    // hàm check khi đăng nhập thành công để reset bộ đếm về 0
+    public void resetFailedLogin(String email, String ipAddress) {
+        securityAttemptDAO.resetAttempts(email, ipAddress, actionTypeLogin);
     }
 
     public User register(String fullName, String email, String username, String plainPassword, String phoneNumber, Timestamp birthday) {

--- a/src/main/java/services/CaptchaVerifier.java
+++ b/src/main/java/services/CaptchaVerifier.java
@@ -1,0 +1,38 @@
+package services;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static services.EmailServices.loadDotenv;
+
+public class CaptchaVerifier {
+    static Dotenv dotenv = loadDotenv();
+    private static final String SECRET_KEY = dotenv.get("CAPTCHA_SECRETKEY", System.getenv("CAPTCHA_SECRETKEY"));
+
+    public static boolean verify(String gRecaptchaResponse) {
+        if (gRecaptchaResponse == null || gRecaptchaResponse.trim().isEmpty()) {
+            return false;
+        }
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            String postData = "secret=" + SECRET_KEY + "&response=" + gRecaptchaResponse;
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://www.google.com/recaptcha/api/siteverify"))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(postData))
+                    .build();
+
+            // Nhận phản hồi trả về từ Google dạng chuỗi JSON
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.body().contains("\"success\": true");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/services/EmailServices.java
+++ b/src/main/java/services/EmailServices.java
@@ -26,18 +26,22 @@ public class EmailServices {
     String username = dotenv.get("EMAIL", System.getenv("EMAIL"));
     String password = dotenv.get("APP_PASSWORD", System.getenv("APP_PASSWORD"));
 
-    public boolean sendOtpEmail(String toEmail, String otp) {
+    private Session baseMailSmtpSetup() {
         Properties props = new Properties();
         props.put("mail.smtp.host", "smtp.gmail.com");
         props.put("mail.smtp.port", "587");
         props.put("mail.smtp.auth", "true");
         props.put("mail.smtp.starttls.enable", "true");
 
-        Session session = Session.getInstance(props, new Authenticator() {
+        return Session.getInstance(props, new Authenticator() {
             protected PasswordAuthentication getPasswordAuthentication() {
                 return new PasswordAuthentication(username, password);
             }
         });
+    }
+
+    public boolean sendOtpEmail(String toEmail, String otp) {
+        Session session = baseMailSmtpSetup();
 
         try {
             Message message = new MimeMessage(session);
@@ -54,17 +58,7 @@ public class EmailServices {
     }
 
     public boolean sendPaymentReminderEmail(String toEmail, int orderId, double amount) {
-        Properties props = new Properties();
-        props.put("mail.smtp.host", "smtp.gmail.com");
-        props.put("mail.smtp.port", "587");
-        props.put("mail.smtp.auth", "true");
-        props.put("mail.smtp.starttls.enable", "true");
-
-        Session session = Session.getInstance(props, new Authenticator() {
-            protected PasswordAuthentication getPasswordAuthentication() {
-                return new PasswordAuthentication(username, password);
-            }
-        });
+        Session session = baseMailSmtpSetup();
 
         try {
             Message message = new MimeMessage(session);
@@ -93,17 +87,7 @@ public class EmailServices {
     }
 
     public boolean sendPaymentFailedEmail(String toEmail, int orderId, double amount) {
-        Properties props = new Properties();
-        props.put("mail.smtp.host", "smtp.gmail.com");
-        props.put("mail.smtp.port", "587");
-        props.put("mail.smtp.auth", "true");
-        props.put("mail.smtp.starttls.enable", "true");
-
-        Session session = Session.getInstance(props, new Authenticator() {
-            protected PasswordAuthentication getPasswordAuthentication() {
-                return new PasswordAuthentication(username, password);
-            }
-        });
+        Session session = baseMailSmtpSetup();
 
         try {
             Message message = new MimeMessage(session);

--- a/src/main/java/services/EmailServices.java
+++ b/src/main/java/services/EmailServices.java
@@ -5,6 +5,8 @@ import jakarta.mail.*;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Properties;
 
 public class EmailServices {
@@ -54,6 +56,59 @@ public class EmailServices {
             return true;
         } catch (MessagingException e) {
             return false;
+        }
+    }
+
+    public void sendWarningBruteForcingMail(String toEmail, String clientIp) {
+        Session session = baseMailSmtpSetup();
+        String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss"));
+        try {
+            Message message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(username)); // username của tài khoản cấu hình SMTP Gmail
+            message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(toEmail));
+
+            message.setSubject("[Cảnh báo Bảo mật] Phát hiện nhiều lần đăng nhập thất bại liên tiếp");
+            String htmlContent = """
+            <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; max-width: 550px; margin: 40px auto; padding: 32px; border: 1px solid #e2e8f0; border-radius: 12px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05); color: #334155;">
+               \s
+                <h2 style="color: #dc2626; font-size: 20px; font-weight: 600; margin-top: 0; margin-bottom: 24px; letter-spacing: -0.5px;">
+                    Cảnh báo bảo mật
+                </h2>
+               \s
+                <p style="margin-top: 0; margin-bottom: 16px;">Xin chào <strong style="color: #0f172a;">%s</strong>,</p>
+                <p style="margin-bottom: 24px;">Hệ thống đã ghi nhận <strong style="color: #dc2626; font-weight: 600;">5 lần đăng nhập thất bại liên tiếp</strong> vào tài khoản của bạn.</p>
+               \s
+                <div style="background-color: #f8fafc; padding: 20px; border-left: 4px solid #dc2626; margin: 24px 0; border-radius: 4px;">
+                    <table style="width: 100%%; border-collapse: collapse; font-size: 14px;">
+                        <tr>
+                            <td style="padding: 4px 0; color: #64748b; width: 100px; vertical-align: top;">Địa chỉ IP</td>
+                            <td style="padding: 4px 0; color: #1e293b; font-weight: 500;">%s</td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 4px 0; color: #64748b; width: 100px; vertical-align: top;">Thời gian</td>
+                            <td style="padding: 4px 0; color: #1e293b; font-weight: 500;">%s</td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 4px 0; color: #64748b; width: 100px; vertical-align: top;">Trạng thái</td>
+                            <td style="padding: 4px 0; color: #b91c1c; font-weight: 500;">Tạm thời chặn kết nối từ IP này trong 15 phút.</td>
+                        </tr>
+                    </table>
+                </div>
+               \s
+                <h3 style="color: #0f172a; font-size: 16px; font-weight: 600; margin-top: 24px; margin-bottom: 12px;">Hướng dẫn xử lý</h3>
+                <ul style="margin: 0; padding-left: 20px; color: #475569;">
+                    <li style="margin-bottom: 8px;"><strong style="color: #1e293b;">Nếu là bạn:</strong> Vui lòng đợi hết thời gian khóa để đăng nhập lại.</li>
+                    <li style="margin-bottom: 8px;"><strong style="color: #1e293b;">Nếu không phải bạn:</strong> Có hành vi dò tìm mật khẩu. Tài khoản hiện tại vẫn an toàn, nhưng chúng tôi khuyến nghị bạn nên <strong style="color: #0284c7;">đổi mật khẩu ngay lập tức</strong> để đảm bảo an toàn.</li>
+                </ul>
+               \s
+                <hr style="border: 0; border-top: 1px solid #edf2f7; margin: 32px 0;">
+                <p style="font-size: 12px; color: #94a3b8; text-align: center; margin: 0;">Đây là email tự động từ hệ thống, vui lòng không phản hồi lại email này.</p>
+            </div>
+           \s""".formatted(toEmail, clientIp, currentTime);
+            message.setContent(htmlContent, "text/html; charset=UTF-8");
+            Transport.send(message);
+            System.out.println("Đã gửi mail cảnh báo bảo mật tới: " + toEmail);
+        } catch (MessagingException ignored) {
         }
     }
 

--- a/src/main/java/services/UserService.java
+++ b/src/main/java/services/UserService.java
@@ -167,6 +167,7 @@ public class UserService {
 
     public String getClientIp(HttpServletRequest request) {
         String[] headerNames = {
+                "CF-Connecting-IP", // cloudflare
                 "X-Forwarded-For",
                 "Proxy-Client-IP",
                 "WL-Proxy-Client-IP"

--- a/src/main/webapp/auth/Authentication.jsp
+++ b/src/main/webapp/auth/Authentication.jsp
@@ -5,6 +5,8 @@
   Time: 8:50 PM
   To change this template use File | Settings | File Templates.
 --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,6 +18,7 @@
 <body>
 <div class="forgot-password-container">
   <h2>Xác Thực</h2>
+  <c:set var="isBlocked" value="${not empty otpError && fn:contains(otpError, 'quá nhiều')}" />
   <form id="forgot-password-form" action="${pageContext.request.contextPath}/authentication" method="POST">
     <input type="hidden" name="action" id="form-action" value="">
     <div class="email-class form-group">
@@ -27,7 +30,8 @@
                placeholder="nguyenanh24@gmail.com"
                value="${not empty pendingUser ? pendingUser.email : (otpEmail != null ? otpEmail : param.email)}"
         <%-- Nếu là luồng Register (có user) thì khóa không cho sửa email --%>
-        ${not empty user ? "readonly" : ""}
+            ${not empty user ? "readonly" : ""}
+            ${isBlocked ? "disabled" : ""}
                class="${not empty emailError ? 'input-error' : ''}" required>
       </div>
       <div class="group-message">
@@ -43,12 +47,12 @@
       <div class="verify-title">
         <label class="label-with-icon"><ion-icon name="chatbox-ellipses-outline"></ion-icon>Mã xác thực</label>
         <div class="otp-container" id="otp-inputs">
-          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" />
-          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" />
-          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" />
-          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" />
-          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" />
-          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" />
+          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" ${isBlocked ? 'disabled' : ''}/>
+          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" ${isBlocked ? 'disabled' : ''}/>
+          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" ${isBlocked ? 'disabled' : ''}/>
+          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" ${isBlocked ? 'disabled' : ''}/>
+          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" ${isBlocked ? 'disabled' : ''}/>
+          <input type="text" maxlength="1" pattern="\d*" inputmode="numeric" class="otp-field" ${isBlocked ? 'disabled' : ''}/>
         </div>
         <input type="hidden" id="verify-code" name="otpInput" required>
       </div>
@@ -59,8 +63,8 @@
     <div class="group-remind">
       <p id="remind">Bạn phải chờ thêm 1 phút để có thể tiếp tục lấy mã</p>
       <div class="group-button-verify">
-        <button class="get-verify-code" onclick="setAction('send-otp')" formnovalidate>Lấy mã xác thực</button>
-        <button class="submit" type="submit" onclick="setAction('finish-otp')">Đồng ý</button>
+        <button class="get-verify-code" onclick="setAction('send-otp')" ${isBlocked ? 'disabled' : ''} formnovalidate>Lấy mã xác thực</button>
+        <button class="submit" type="submit" onclick="setAction('finish-otp')" ${isBlocked ? 'disabled' : ''}>Đồng ý</button>
       </div>
     </div>
     <a href="login" id="backward">Quay Lại Trang Trước</a>
@@ -94,6 +98,18 @@
   }
   input.input-error {
     border: 1px solid red;
+  }
+
+  input[disabled], button[disabled] {
+    background-color: #f1f3f5 !important;
+    color: #adb5bd !important;
+    border: 1px solid #ced4da !important;
+    cursor: not-allowed !important;
+    opacity: 0.7;
+  }
+  button[disabled] {
+    box-shadow: none !important;
+    pointer-events: none;
   }
 </style>
 <script>

--- a/src/main/webapp/auth/Login.jsp
+++ b/src/main/webapp/auth/Login.jsp
@@ -27,7 +27,7 @@
     </div>
     <div class="login-page">
         <h2>Đăng Nhập</h2>
-        <c:set var="isBlocked" value="${not empty loginError && fn:contains(loginError, '5 lần')}" />
+        <c:set var="isBlocked" value="${not empty loginError && fn:contains(loginError, 'quá nhiều')}" />
         <form id="login-form" action="${pageContext.request.contextPath}/login" method="POST">
             <input type="hidden" name="redirect" value="${fn:escapeXml(param.redirect)}">
             <div class="username-input">

--- a/src/main/webapp/auth/Login.jsp
+++ b/src/main/webapp/auth/Login.jsp
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="${pageContext.request.contextPath}/auth/auth_css/login.css">
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
 <div class="main-container">
@@ -28,6 +29,7 @@
     <div class="login-page">
         <h2>Đăng Nhập</h2>
         <c:set var="isBlocked" value="${not empty loginError && fn:contains(loginError, 'quá nhiều')}" />
+        <c:set var="showCaptcha" value="${failedAttempts >= 3 && failedAttempts < 5}" />
         <form id="login-form" action="${pageContext.request.contextPath}/login" method="POST">
             <input type="hidden" name="redirect" value="${fn:escapeXml(param.redirect)}">
             <div class="username-input">
@@ -69,7 +71,9 @@
                     <span class="error-msg">${loginError}</span>
                 </c:if>
             </div>
-
+            <c:if test="${showCaptcha == true}">
+                <div class="g-recaptcha" data-sitekey="6LfbNAItAAAAAFdmKqwOuF4XNDyT40RtO2B459S7"></div>
+            </c:if>
             <div class="remember-me-input">
                 <a href="authentication">Quên Mật Khẩu</a>
             </div>

--- a/src/main/webapp/auth/Login.jsp
+++ b/src/main/webapp/auth/Login.jsp
@@ -27,6 +27,7 @@
     </div>
     <div class="login-page">
         <h2>Đăng Nhập</h2>
+        <c:set var="isBlocked" value="${not empty loginError && fn:contains(loginError, '5 lần')}" />
         <form id="login-form" action="${pageContext.request.contextPath}/login" method="POST">
             <input type="hidden" name="redirect" value="${fn:escapeXml(param.redirect)}">
             <div class="username-input">
@@ -35,7 +36,8 @@
                     Nhập tên tài khoản hoặc email hiện có</label>
                 <input type="text" id="username" name="username" placeholder="anhnguyen12, anhnguyen25@gmail.com"
                        value="${param.username}"
-                       class="${not empty usernameError or not empty inputError or not empty loginError ? 'input-error' : ''}" required>
+                       class="${not empty usernameError or not empty inputError or not empty loginError ? 'input-error' : ''}"
+                       ${isBlocked ? 'disabled' : ''} required>
                 <c:if test="${not empty inputError}">
                     <span class="error-msg">${inputError}</span>
                 </c:if>
@@ -55,7 +57,7 @@
                     <input type="password" id="password" name="password"
                            placeholder="Anhnguyen@25"
                            class="${not empty inputError ? 'input-error' : ''}"
-                           required>
+                           ${isBlocked ? 'disabled' : ''} required>
                     <span id="eyeIcon">
                         <ion-icon name="eye-off-outline"></ion-icon>
                     </span>
@@ -71,7 +73,7 @@
             <div class="remember-me-input">
                 <a href="authentication">Quên Mật Khẩu</a>
             </div>
-            <button>Đăng Nhập</button>
+            <button ${isBlocked ? 'disabled' : ''}>Đăng Nhập</button>
             <div class="register-account">
                 <div id="register-remind">Chưa có tài khoản?</div>
                 <a href="register">Đăng Kí</a>
@@ -175,6 +177,19 @@
     }
     input.input-error {
         border: 1px solid red;
+    }
+
+    /* các thành phần bị khóa (disabled) */
+    input[disabled], button[disabled] {
+        background-color: #f1f3f5 !important;
+        color: #adb5bd !important;
+        border: 1px solid #ced4da !important;
+        cursor: not-allowed !important;
+        opacity: 0.7;
+    }
+    button[disabled] {
+        box-shadow: none !important;
+        pointer-events: none;
     }
 </style>
 </body>

--- a/src/main/webapp/auth/Register.jsp
+++ b/src/main/webapp/auth/Register.jsp
@@ -13,6 +13,7 @@
   <title>Register</title>
   <link rel="stylesheet" href="${pageContext.request.contextPath}/auth/auth_css/register.css">
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
 <div class="register-page">
@@ -159,6 +160,10 @@
         <label for="license-confirm">Xác nhận bạn sẽ tuân thủ chính sách</label>
       </div>
     </div>
+    <div class="g-recaptcha" data-sitekey="6LfbNAItAAAAAFdmKqwOuF4XNDyT40RtO2B459S7" style="margin-bottom: 10px; margin-top:10px"></div>
+    <c:if test="${not empty registerError}">
+      <span class="error-msg">${registerError}</span>
+    </c:if>
     <button type="submit">Đăng Kí</button>
     <div class="social-login">
       <div id="social-remind">Chọn phương thức khác để đăng nhập:</div>


### PR DESCRIPTION
> Sửa issues
- #91 

> Chi tiết
- Áp dụng reCAPTCHA cho Login _(với số attempt fail lên đến mức 3)_ và khoá form đăng nhập theo cặp
**`UNIQUE KEY idx_security (ip_address, target_email, action_type)`** _(với số attempt fail lên đến mức 5) (kéo dài 15p)_
<img width="623" height="138" alt="image" src="https://github.com/user-attachments/assets/123379c2-64a4-47b3-824d-9405521e9dd8" />

- Áp dụng reCAPTCHA cho Register (ngay từ đầu) và khoá đăng kí nếu cố tình đăng kí quá attempt nhiều lần _(kéo dài 1 ngày)_
<img width="928" height="220" alt="image" src="https://github.com/user-attachments/assets/b77501a0-4b07-4f78-a3de-58386535054d" />

- Áp dụng rate-limiting cho Authentication và khoá form xác thực nếu cố tình sai attempts nhập OTP nhiều
- Vẫn giữ cooldown lấy mã OTP là 1 phút
